### PR TITLE
Fix case when retuning timeout error

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ module.exports = async function (url, options) {
 
                 if (!retry(retryOptions, error, null)) {
                     if (error.name === 'AbortError') {
-                        return reject(new FetchError('Network timeout', 'request-timeout'));
+                        return reject(new FetchError('network timeout', 'request-timeout'));
                     }
 
                     return reject(error);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "test": "nyc mocha --recursive --exit",
+    "test:watch": "nyc mocha --recursive --watch",
     "posttest": "eslint . && license-checker --summary",
     "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "beautify": "eslint . --fix"


### PR DESCRIPTION
## Description

The current build in `master` is failing in the tests. The problem is quite silly as it fails because of an unmatched case in a string comparison. This PR fixes the error case in the return value.

As a "bonus" I added a `test:watch` command to `package.json`.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
