### PR TITLE
Handle case where url is FetchRequest

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function checkParameters(retryOptions) {
  */
 /**
  * Fetch retry that wraps around `node-fetch` library
- * @param {String} url request url
+ * @param {String|FetchRequest} url request url or FetchRequest
  * @param {Options} options options for fetch request (e.g. headers, RetryOptions for retries or `false` if no do not want to perform retries)
  * @returns {Object} json response of calling fetch 
  */
@@ -173,7 +173,7 @@ module.exports = async function (url, options) {
 
                 if (!retry(retryOptions, error, null)) {
                     if (error.name === 'AbortError') {
-                        return reject(new FetchError(`network timeout at ${url}`, 'request-timeout'));
+                        return reject(new FetchError(`network timeout at ${typeof url === 'string' ? url : url.url}`, 'request-timeout'));
                     }
 
                     return reject(error);


### PR DESCRIPTION
## Description

This PR handles the case where `url` is an instance of `FetchRequest` which is supported by `node-fetch`. Currently, the following is logged in case of a timeout: `network timeout at [object Request]`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
