### PR TITLE
release in linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@
 
 language: node_js
 os:
-  - windows
   - linux
+  - windows
   - osx
 
 node_js:


### PR DESCRIPTION
## Description

the release did not work because we only release on the [condition](https://github.com/adobe/node-fetch-retry/blob/master/.travis.yml#L41) we are running in `linux` but travis naively chooses the first OS listed to release in, which was windows:
https://travis-ci.com/github/adobe/node-fetch-retry/builds/192167094
https://travis-ci.com/github/adobe/node-fetch-retry/jobs/405316758#L8

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
