### PR TITLE
Travis CI: add sizewatcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,6 @@ jobs:
 
 after_success:
   - npm run report-coverage
+
+after_script:
+  - npx @adobe/sizewatcher


### PR DESCRIPTION
This updates the travis CI jobs to run [@adobe/sizewatcher](https://github.com/adobe/sizewatcher).

This tool warns if pull requests introduce large size increases (e.g. npm modules dependencies, package size etc.).