### PR TITLE
Fix passing `retryOptions` by reference.

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ function checkParameters(retryOptions) {
  * @returns {Object} json response of calling fetch 
  */
 module.exports = async function (url, options) {
-    options = options || {};
+    options = {...options} || {};
     const retryOptions = retryInit(options); // set up retry options or set to default settings if not set
     delete options.retryOptions; // remove retry options from options passed to actual fetch
     let attempt = 0;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -729,4 +729,20 @@ describe('test fetch retry', () => {
         const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`);
         assert.strictEqual(response.ok, true);
     });
+    
+    it('doesn\'t modify the passed in options', async () => {
+        nock(FAKE_BASE_URL)
+            .get(FAKE_PATH)
+            .reply(200, { ok: true });
+        
+        const options = {
+            retryOptions: {
+                retryMaxDuration: 3000
+            }
+        };
+        
+        await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`, options);
+
+        assert.strictEqual(options.retryOptions.retryMaxDuration, 3000);
+    });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -730,7 +730,7 @@ describe('test fetch retry', () => {
         assert.strictEqual(response.ok, true);
     });
     
-    it('doesn\'t modify the passed in options', async () => {
+    it("doesn't modify the passed in options", async () => {
         nock(FAKE_BASE_URL)
             .get(FAKE_PATH)
             .reply(200, { ok: true });


### PR DESCRIPTION
## Description

In the following scenario, I discovered that the passed in `options` seemed to be getting reset somehow as it was being used by reference internally:

```
const fetchOptions = {
    retryOptions: {
        // options here
    }
};

async function one() {
  fetch("/url1", fetchOptions);
}

async function two() {
  fetch("/url2", fetchOptions);
}
```

Now the internal `options` are "spread" out when received so that the original `fetchOptions` remains unaffected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
