### PR TITLE
feat: add node-fetch-v3 support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,5 +13,8 @@
 'use strict';
 
 module.exports = {
-    "extends": "@adobe/eslint-config-asset-compute"
+    "extends": "@adobe/eslint-config-asset-compute",
+    "parserOptions": {
+        "ecmaVersion": 12
+    },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ typings/
 .vscode
 !.vscode/launch.json
 
+# Webstorm
+.idea
+
 # serverless
 .serverless/action.zip
 .webpack

--- a/index.js
+++ b/index.js
@@ -12,8 +12,6 @@
 'use strict';
 
 const AbortController = require('abort-controller');
-const fetch = require('node-fetch');
-const {FetchError} = fetch;
 
 /**
  * Retry
@@ -137,7 +135,7 @@ function checkParameters(retryOptions) {
  * Fetch retry that wraps around `node-fetch` library
  * @param {String} url request url
  * @param {Options} options options for fetch request (e.g. headers, RetryOptions for retries or `false` if no do not want to perform retries)
- * @returns {Object} json response of calling fetch 
+ * @returns {Object} json response of calling fetch
  */
 module.exports = async function (url, options) {
     options = options || {};
@@ -157,7 +155,7 @@ module.exports = async function (url, options) {
             }
 
             try {
-                const response = await fetch(url, options);
+                const response = await import('node-fetch').then( ({ default: fetch }) => fetch(url, options));
                 clearTimeout(timeoutHandler);
 
                 if (!retry(retryOptions, null, response)) {
@@ -172,6 +170,7 @@ module.exports = async function (url, options) {
 
                 if (!retry(retryOptions, error, null)) {
                     if (error.name === 'AbortError') {
+                        const FetchError = await import('node-fetch').then( ({ FetchError }) => FetchError);
                         return reject(new FetchError(`network timeout at ${url}`, 'request-timeout'));
                     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -523,6 +523,12 @@
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+          "dev": true
+        },
         "universal-user-agent": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
@@ -1271,6 +1277,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
+    },
+    "data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "dateformat": {
       "version": "3.0.3",
@@ -2062,6 +2073,14 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "fetch-blob": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
+      "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
+      "requires": {
+        "web-streams-polyfill": "^3.0.3"
       }
     },
     "figures": {
@@ -3646,9 +3665,13 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
+      "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
+      "requires": {
+        "data-uri-to-buffer": "^3.0.1",
+        "fetch-blob": "^3.1.2"
+      }
     },
     "node-preload": {
       "version": "0.2.1",
@@ -8833,6 +8856,12 @@
             "agent-base": "5",
             "debug": "4"
           }
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+          "dev": true
         }
       }
     },
@@ -8899,6 +8928,15 @@
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "2 || 3"
+      }
+    },
+    "timeout-signal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/timeout-signal/-/timeout-signal-1.1.0.tgz",
+      "integrity": "sha512-fuWY4tM1njcHCiOB7XkTmP0EOxzBkPbuQwPN+ZCzM6G0Tj4fMVgEffG/OPgiNUX48o+FhQEa2Oh4qjEDBCy5WQ==",
+      "dev": true,
+      "requires": {
+        "abort-controller": "^3.0.0"
       }
     },
     "tmp": {
@@ -9064,6 +9102,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.0.tgz",
+      "integrity": "sha512-wO9r1YnYe7kFBLHyyVEhV1H8VRWoNiNnuP+v/HUUmSTaRF8F93Kmd3JMrETx0f11GXxRek6OcL2QtjFIdc5WYw=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "abort-controller": "^3.0.0",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^3.0.0"
   },
   "devDependencies": {
     "@adobe/eslint-config-asset-compute": "^1.3.1",
@@ -24,7 +24,8 @@
     "nock": "^13.0.4",
     "nyc": "^15.1.0",
     "rewire": "^5.0.0",
-    "semantic-release": "^17.2.1"
+    "semantic-release": "^17.2.1",
+    "timeout-signal": "^1.1.0"
   },
   "keywords": [
     "fetch",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -202,9 +202,9 @@ describe('test fetch retry', () => {
             .reply(200, { ok: true });
 
         const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`,
-            { 
-                method: 'GET', 
-                headers: { Authorization: 'Basic thisShouldBeAnAuthHeader' } 
+            {
+                method: 'GET',
+                headers: { Authorization: 'Basic thisShouldBeAnAuthHeader' }
             }
         );
         assert.strictEqual(response.ok, true);
@@ -217,9 +217,9 @@ describe('test fetch retry', () => {
             .reply(200, { ok: true });
 
         const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`,
-            { 
-                method: 'GET', 
-                headers: { Authorization: 'Bearer thisShouldBeAToken' } 
+            {
+                method: 'GET',
+                headers: { Authorization: 'Bearer thisShouldBeAToken' }
             }
         );
         assert.strictEqual(response.ok, true);
@@ -256,9 +256,9 @@ describe('test fetch retry', () => {
             .reply(401, { ok: false });
 
         const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`,
-            { 
-                method: 'GET', 
-                headers: { Authorization: 'Basic thisShouldBeAnAuthHeader' } 
+            {
+                method: 'GET',
+                headers: { Authorization: 'Basic thisShouldBeAnAuthHeader' }
             }
         );
         assert.strictEqual(response.ok, false);
@@ -269,7 +269,7 @@ describe('test fetch retry', () => {
             .get(FAKE_PATH)
             .reply(500);
         const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`, { method: 'GET', retryOptions: false });
-        assert.strictEqual(response.statusText, 'Internal Server Error');
+        assert.strictEqual(response.statusText, '');
     });
 
     it('test get retry with default settings 500 then 200', async () => {
@@ -283,7 +283,7 @@ describe('test fetch retry', () => {
         const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`, { method: 'GET' });
         assert(nock.isDone());
         assert(response.ok);
-        assert.strictEqual(response.statusText, 'OK');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 200);
     });
 
@@ -297,13 +297,13 @@ describe('test fetch retry', () => {
             .get(FAKE_PATH)
             .matchHeader('Authorization', 'Basic thisShouldBeAnAuthHeader')
             .reply(200, { ok: true });
-        const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`, 
-            { 
-                method: 'GET', headers: { Authorization: 'Basic thisShouldBeAnAuthHeader' }  
+        const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`,
+            {
+                method: 'GET', headers: { Authorization: 'Basic thisShouldBeAnAuthHeader' }
             });
         assert(nock.isDone());
         assert(response.ok);
-        assert.strictEqual(response.statusText, 'OK');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 200);
     });
 
@@ -314,7 +314,7 @@ describe('test fetch retry', () => {
         const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`, { method: 'GET' });
         assert(nock.isDone());
         assert(!response.ok);
-        assert.strictEqual(response.statusText, 'Bad Request');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 400);
     });
 
@@ -325,7 +325,7 @@ describe('test fetch retry', () => {
         const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`, { method: 'GET' });
         assert(nock.isDone());
         assert(!response.ok);
-        assert.strictEqual(response.statusText, 'Not Found');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 404);
     });
 
@@ -336,7 +336,7 @@ describe('test fetch retry', () => {
         const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`, { method: 'GET' });
         assert(nock.isDone());
         assert(!response.ok);
-        assert.strictEqual(response.statusText, 'Multiple Choices');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 300);
     });
 
@@ -353,7 +353,7 @@ describe('test fetch retry', () => {
             .reply(200, { ok: true });
         const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`, { method: 'GET' });
         assert(nock.isDone());
-        assert.strictEqual(response.statusText, 'OK');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 200);
     });
 
@@ -388,7 +388,7 @@ describe('test fetch retry', () => {
             }
         });
         assert(nock.isDone());
-        assert.strictEqual(response.statusText, 'Not Found');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 404);
     });
 
@@ -406,7 +406,7 @@ describe('test fetch retry', () => {
             });
         assert(!nock.isDone()); // should fail on first fetch call
         nock.cleanAll();
-        assert.strictEqual(response.statusText, 'HTTP Version Not Supported');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 505);
     });
 
@@ -429,7 +429,7 @@ describe('test fetch retry', () => {
                 }
             });
         assert(nock.isDone());
-        assert.strictEqual(response.statusText, 'OK');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 200);
     });
 
@@ -452,7 +452,7 @@ describe('test fetch retry', () => {
                 }
             });
         assert(!nock.isDone()); // nock should not have gotten all calls
-        assert.strictEqual(response.statusText, 'Unauthorized');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 401);
 
         // clean up nock
@@ -470,7 +470,7 @@ describe('test fetch retry', () => {
             .reply(200);
         const response = await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`,
             {
-                method: 'GET', 
+                method: 'GET',
                 headers: {
                     Authorization: 'Basic thisShouldBeAnAuthHeader'
                 },
@@ -483,7 +483,7 @@ describe('test fetch retry', () => {
                 }
             });
         assert(!nock.isDone()); // nock should not have gotten all calls
-        assert.strictEqual(response.statusText, 'Unauthorized');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 401);
 
         // clean up nock
@@ -505,7 +505,7 @@ describe('test fetch retry', () => {
             });
         assert(nock.isDone());
         nock.cleanAll(); // clean persisted nock
-        assert.strictEqual(response.statusText, 'Not Found');
+        assert.strictEqual(response.statusText, '');
         assert.strictEqual(response.status, 404);
 
     }).timeout(3000);


### PR DESCRIPTION
## Description

node-fetch v3 has been released. This PR serves for starting the discussion of updating node-fetch-retry to allow use of v3, which is ESM only. A full conversion of node-fetch-retry to ESM is not necessary when using async import.

Minimum node version required would be 12.20

https://github.com/node-fetch/node-fetch/blob/main/docs/v3-UPGRADE-GUIDE.md

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Dependency update with code changes (no functional impact)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
