### PR TITLE
always retry on errors if there is enough time left

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ function isResponseTimedOut(retryOptions) {
 function shouldRetry(retryOptions, error, response, waitTime) {
     if (getTimeRemaining(retryOptions) < waitTime) {
         return false;
+    } else if (error !== null) {
+        return true;
     } else if (retryOptions && retryOptions.retryOnHttpResponse) {
         return retryOptions.retryOnHttpResponse(response);
     } else {


### PR DESCRIPTION
## Description

before the refactoring, the behavior was to always retry (if there is enough time) on http errors:
```
return ((totalMillisToWait < retryOptions.retryMaxDuration) &&
            (error !== null || (retryOptions.retryOnHttpResponse && (retryOptions.retryOnHttpResponse(response))))
        );
```

the change to only retry on 5xx http error code's (by default) broke a dep mod failing test: https://git.corp.adobe.com/nui/auth/pull/63
```
  56 passing (1s)
  1 failing

  1) auth.js
       access token validation
         accept a request even if the IMS key URL temporarily fails:
     Error: the object {
  "body": {
    "message": [undefined]
    "ok": false
  }
  "statusCode": 403
} was thrown, throw an Error :)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
