### PR TITLE
[BLOCKED] ASSETS-14 [regression] bring back behavior to retry on network timeouts by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,8 +149,12 @@ function checkParameters(retryOptions) {
 function shouldRetryOnHttpError(error) {
     // special handling for known fetch errors: https://github.com/node-fetch/node-fetch/blob/main/docs/ERROR-HANDLING.md
     // retry on all errors originating from Node.js core
+    // retry on AbortError caused by network timeouts
     if (error.name === 'FetchError' && error.type === 'system') {
         console.error(`FetchError failed with code: ${error.code}; message: ${error.message}`);
+        return true;
+    } else if (error.name === 'AbortError') {
+        console.error(`AbortError failed with type: ${error.type}; message: ${error.message}`);
         return true;
     }
     return false;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -181,6 +181,7 @@ describe('test `retryInit` function', () => {
         assert.strictEqual(retryOptions.retryOnHttpResponse({ status: 400 }), false);
         assert.strictEqual(retryOptions.socketTimeout, 1500); // gets set to half the retryMaxDuration
     });
+
     it('socket timeout is larger than retry max duration but `forceSocketTimeout` is true', () => {
         const rewiredFetchRetry = rewire('../index');
         const retryInit = rewiredFetchRetry.__get__('retryInit');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -664,7 +664,6 @@ describe('test fetch retry', () => {
 
     it("verifies handling of socket timeout when socket times out - use retryMax as timeout value (after first failure)", async () => {
         const socketTimeout = 50000;
-
         console.log("!! Test http server ----------");
         // The test needs to be able to control the server socket
         // (which nock or whatever-http-mock can't).

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -852,7 +852,6 @@ describe('test fetch retry on http errors (throw exceptions)', () => {
                 message: 'something awful happened',
                 code: '503',
             });
-        const timer = new Timer();
         try {
             await fetch(`${FAKE_BASE_URL}${FAKE_PATH}`, { method: 'GET', retryOptions: { retryMaxDuration: 2 } });
             assert.fail("Should have thrown an error!");
@@ -860,8 +859,7 @@ describe('test fetch retry on http errors (throw exceptions)', () => {
             assert(e.message.includes("network timeout"));
             assert(e.type === "request-timeout");
         }
-        console.log(`ellapsed: ${timer.ellapsed}`);
-        assert.ok(timer.isBetween(1, 1000), "Should have taken less than 1 second");
+        assert(nock.isDone());
     });
     it('test network timeout is retried once [mocked]', async () => {
         nock(FAKE_BASE_URL)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -861,7 +861,7 @@ describe('test fetch retry on http errors (throw exceptions)', () => {
             assert(e.type === "request-timeout");
         }
         console.log(`ellapsed: ${timer.ellapsed}`);
-        assert.ok(timer.isBetween(1, 100), "Should have taken approximately 10ms");
+        assert.ok(timer.isBetween(1, 1000), "Should have taken less than 1 second");
     });
     it('test network timeout is retried once [mocked]', async () => {
         nock(FAKE_BASE_URL)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -219,6 +219,7 @@ describe('test `retryInit` function', () => {
         assert.strictEqual(retryOptions.retryOnHttpResponse({ status: 500 }), true);
         assert.strictEqual(retryOptions.retryOnHttpResponse({ status: 400 }), false);
     });
+
     it('custom retry on http response', () => {
         const rewiredFetchRetry = rewire('../index');
         const retryInit = rewiredFetchRetry.__get__('retryInit');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -52,6 +52,7 @@ describe('test `retryInit` function', () => {
         delete process.env.NODE_FETCH_RETRY_INITIAL_WAIT;
         delete process.env.NODE_FETCH_RETRY_FORCE_TIMEOUT;
     });
+
     it('no params, use default values', () => {
         const rewiredFetchRetry = rewire('../index');
         const retryInit = rewiredFetchRetry.__get__('retryInit');


### PR DESCRIPTION
## Description

### Background
Since refactoring the logic, we stopped retrying on network timeouts (`AbortError`). This PR aims to restore previous logic and retry at least once on network timeouts.

### Details
Before the refactoring, we used to [always retry on http errors](https://github.com/adobe/node-fetch-retry/blob/4161e438c4014f69a31f575578714764c17fdfee/index.js#L29), regardless of response. Then the refactoring made us only retry on `FetchError`'s, which don't include network timeouts.

So we see transient network errors timing out before `retryMaxDuration` is reached and not getting retried. Default socket timeout is 30s, so the requests should be retried at least once since the default max retry duration is 60s. We actually make sure socket timeout is half of max retry duration to ensure at least 1 retry: https://github.com/adobe/node-fetch-retry/blob/master/index.js#L82, but that was not happening.

We have been seeing an increase in network times from this change: https://onenr.io/0DvwB7qPoRp. A customer even opened up a bug ticket for this.

The fix is simply to retry on `AbortError`'s if there is enough time left (as long as `maxRetryDuration` hasn't been reached). 
The refactoring also made retry logic on http responses configurable, so clients can always add custom behavior if they don't want to retry on network timeouts.

Fixes # https://jira.corp.adobe.com/browse/ASSETS-14
customer reported issue: https://jira.corp.adobe.com/browse/CQ-4339944

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
