### PR TITLE
run github actions on all pull requests - not just against master

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Currently Github actions only runs on pull requests against master. This PR changes that.

Since we have the `version3` branch now with multiple pull requests going into that branch first, it would be nice to run github actions on all PRs. An example is #93 which did not run the actions.